### PR TITLE
feat: add themed UI components

### DIFF
--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
-import { View, TextInput, Button, Text } from "react-native";
+import { Text } from "react-native";
 import { supabase } from "../lib/supabase";
+import { Button, TextInput, Card } from "./theme/components";
+import { tokens } from "./theme/tokens";
 
 export default function AuthScreen({ onAuthed }: { onAuthed: () => void }) {
   const [email, setEmail] = useState("");
@@ -10,20 +12,40 @@ export default function AuthScreen({ onAuthed }: { onAuthed: () => void }) {
 
   async function go() {
     setErr(null);
-    const fn = mode === "in" ? supabase.auth.signInWithPassword : supabase.auth.signUp;
+    const fn =
+      mode === "in" ? supabase.auth.signInWithPassword : supabase.auth.signUp;
     const { error } = await fn({ email, password: pw });
     if (error) setErr(error.message);
     else onAuthed();
   }
 
   return (
-    <View style={{ padding: 24, gap: 12 }}>
-      <Text style={{ fontSize: 24, fontWeight: "600" }}>MediTrack Diabetes</Text>
-      <TextInput placeholder="Email" autoCapitalize="none" onChangeText={setEmail} value={email} />
-      <TextInput placeholder="Password" secureTextEntry onChangeText={setPw} value={pw} />
-      {err && <Text style={{ color: "red" }}>{err}</Text>}
+    <Card style={{ padding: tokens.space(3), gap: tokens.space(1.5) }}>
+      <Text style={{ fontSize: 24, fontWeight: "600" }}>
+        MediTrack Diabetes
+      </Text>
+      <TextInput
+        placeholder="Email"
+        autoCapitalize="none"
+        onChangeText={setEmail}
+        value={email}
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry
+        onChangeText={setPw}
+        value={pw}
+      />
+      {err && <Text style={{ color: tokens.color.danger }}>{err}</Text>}
       <Button title={mode === "in" ? "Sign In" : "Sign Up"} onPress={go} />
-      <Button title={mode === "in" ? "Need an account? Sign Up" : "Have an account? Sign In"} onPress={() => setMode(mode === "in" ? "up" : "in")} />
-    </View>
+      <Button
+        title={
+          mode === "in"
+            ? "Need an account? Sign Up"
+            : "Have an account? Sign In"
+        }
+        onPress={() => setMode(mode === "in" ? "up" : "in")}
+      />
+    </Card>
   );
 }

--- a/src/screens/Auth.tsx
+++ b/src/screens/Auth.tsx
@@ -1,7 +1,8 @@
-
 import React, { useState } from "react";
-import { View, TextInput, Button, Text } from "react-native";
+import { Text } from "react-native";
 import { supabase } from "../lib/supabase";
+import { Button, TextInput, Card } from "../theme/components";
+import { tokens } from "../theme/tokens";
 
 export default function AuthScreen({ onAuthed }: { onAuthed: () => void }) {
   const [email, setEmail] = useState("");
@@ -11,20 +12,40 @@ export default function AuthScreen({ onAuthed }: { onAuthed: () => void }) {
 
   async function go() {
     setErr(null);
-    const fn = mode === "in" ? supabase.auth.signInWithPassword : supabase.auth.signUp;
+    const fn =
+      mode === "in" ? supabase.auth.signInWithPassword : supabase.auth.signUp;
     const { error } = await fn({ email, password: pw });
     if (error) setErr(error.message);
     else onAuthed();
   }
 
   return (
-    <View style={{ padding: 24, gap: 12 }}>
-      <Text style={{ fontSize: 24, fontWeight: "600" }}>MediTrack Diabetes</Text>
-      <TextInput placeholder="Email" autoCapitalize="none" onChangeText={setEmail} value={email} />
-      <TextInput placeholder="Password" secureTextEntry onChangeText={setPw} value={pw} />
-      {err && <Text style={{ color: "red" }}>{err}</Text>}
+    <Card style={{ padding: tokens.space(3), gap: tokens.space(1.5) }}>
+      <Text style={{ fontSize: 24, fontWeight: "600" }}>
+        MediTrack Diabetes
+      </Text>
+      <TextInput
+        placeholder="Email"
+        autoCapitalize="none"
+        onChangeText={setEmail}
+        value={email}
+      />
+      <TextInput
+        placeholder="Password"
+        secureTextEntry
+        onChangeText={setPw}
+        value={pw}
+      />
+      {err && <Text style={{ color: tokens.color.danger }}>{err}</Text>}
       <Button title={mode === "in" ? "Sign In" : "Sign Up"} onPress={go} />
-      <Button title={mode === "in" ? "Need an account? Sign Up" : "Have an account? Sign In"} onPress={() => setMode(mode === "in" ? "up" : "in")} />
-    </View>
+      <Button
+        title={
+          mode === "in"
+            ? "Need an account? Sign Up"
+            : "Have an account? Sign In"
+        }
+        onPress={() => setMode(mode === "in" ? "up" : "in")}
+      />
+    </Card>
   );
 }

--- a/src/screens/Dashboard.tsx
+++ b/src/screens/Dashboard.tsx
@@ -1,16 +1,30 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, Button, FlatList, TouchableOpacity } from "react-native";
+import { View, Text, FlatList, TouchableOpacity } from "react-native";
+import { Button, Card } from "../theme/components";
+import { tokens } from "../theme/tokens";
 import { listPrescriptions, deletePrescription, Rx } from "../services/rx";
 import { scheduleRefillReminder } from "../lib/notify";
 
-export default function Dashboard({ onAdd, onEdit }: { onAdd: () => void; onEdit: (rx: Rx) => void }) {
+export default function Dashboard({
+  onAdd,
+  onEdit,
+}: {
+  onAdd: () => void;
+  onEdit: (rx: Rx) => void;
+}) {
   const [items, setItems] = useState<Rx[]>([]);
   const [loading, setLoading] = useState(true);
   async function load() {
     setLoading(true);
-    try { setItems(await listPrescriptions()); } finally { setLoading(false); }
+    try {
+      setItems(await listPrescriptions());
+    } finally {
+      setLoading(false);
+    }
   }
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    load();
+  }, []);
 
   async function schedule(rx: Rx) {
     if (rx.next_refill_date) {
@@ -21,30 +35,57 @@ export default function Dashboard({ onAdd, onEdit }: { onAdd: () => void; onEdit
     }
   }
 
-  if (loading) return <View style={{ padding: 24 }}><Text>Loading…</Text></View>;
+  if (loading)
+    return (
+      <View style={{ padding: tokens.space(3) }}>
+        <Text>Loading…</Text>
+      </View>
+    );
 
   return (
-    <View style={{ padding: 24, gap: 12, flex: 1 }}>
-      <Text style={{ fontSize: 22, fontWeight: "600" }}>Your prescriptions</Text>
+    <View style={{ padding: tokens.space(3), gap: tokens.space(1.5), flex: 1 }}>
+      <Text style={{ fontSize: 22, fontWeight: "600" }}>
+        Your prescriptions
+      </Text>
       <Button title="Add prescription" onPress={onAdd} />
       {items.length === 0 ? (
-        <Text style={{ marginTop: 12 }}>No prescriptions yet.</Text>
+        <Text style={{ marginTop: tokens.space(1.5) }}>
+          No prescriptions yet.
+        </Text>
       ) : (
         <FlatList
           data={items}
           keyExtractor={(x) => x.id}
           renderItem={({ item }) => (
-            <View style={{ padding: 12, borderWidth: 1, borderRadius: 8, marginVertical: 6 }}>
+            <Card style={{ marginVertical: tokens.space(0.75) }}>
               <TouchableOpacity onPress={() => onEdit(item)}>
                 <Text style={{ fontWeight: "600" }}>{item.name}</Text>
-                <Text>{item.dosage ?? ""} • {item.frequency ?? ""}</Text>
+                <Text>
+                  {item.dosage ?? ""} • {item.frequency ?? ""}
+                </Text>
                 <Text>Next refill: {item.next_refill_date ?? "—"}</Text>
               </TouchableOpacity>
-              <View style={{ flexDirection: "row", gap: 8, marginTop: 8 }}>
-                <Button title="Schedule reminder" onPress={() => schedule(item)} />
-                <Button title="Delete" color="#b00020" onPress={async () => { await deletePrescription(item.id); await load(); }} />
+              <View
+                style={{
+                  flexDirection: "row",
+                  gap: tokens.space(1),
+                  marginTop: tokens.space(1),
+                }}
+              >
+                <Button
+                  title="Schedule reminder"
+                  onPress={() => schedule(item)}
+                />
+                <Button
+                  title="Delete"
+                  style={{ backgroundColor: tokens.color.danger }}
+                  onPress={async () => {
+                    await deletePrescription(item.id);
+                    await load();
+                  }}
+                />
               </View>
-            </View>
+            </Card>
           )}
         />
       )}

--- a/src/screens/RxForm.tsx
+++ b/src/screens/RxForm.tsx
@@ -1,8 +1,16 @@
 import React, { useState } from "react";
-import { View, TextInput, Button, Text } from "react-native";
+import { View, Text } from "react-native";
 import { insertPrescription, updatePrescription, Rx } from "../services/rx";
+import { Button, TextInput, Card } from "../theme/components";
+import { tokens } from "../theme/tokens";
 
-export default function RxForm({ initial, onSaved }: { initial?: Rx; onSaved: () => void }) {
+export default function RxForm({
+  initial,
+  onSaved,
+}: {
+  initial?: Rx;
+  onSaved: () => void;
+}) {
   const [name, setName] = useState(initial?.name ?? "");
   const [dosage, setDosage] = useState(initial?.dosage ?? "");
   const [frequency, setFrequency] = useState(initial?.frequency ?? "");
@@ -13,7 +21,13 @@ export default function RxForm({ initial, onSaved }: { initial?: Rx; onSaved: ()
   async function save() {
     try {
       setErr(null);
-      const payload = { name, dosage, frequency, next_refill_date: nextRefill || null, notes };
+      const payload = {
+        name,
+        dosage,
+        frequency,
+        next_refill_date: nextRefill || null,
+        notes,
+      };
       if (initial) await updatePrescription(initial.id, payload);
       else await insertPrescription(payload);
       onSaved();
@@ -23,15 +37,35 @@ export default function RxForm({ initial, onSaved }: { initial?: Rx; onSaved: ()
   }
 
   return (
-    <View style={{ padding: 24, gap: 12 }}>
-      <Text style={{ fontSize: 18, fontWeight: "600" }}>{initial ? "Edit" : "Add"} prescription</Text>
-      <TextInput placeholder="Name *" value={name} onChangeText={setName} />
-      <TextInput placeholder="Dosage" value={dosage ?? ""} onChangeText={setDosage} />
-      <TextInput placeholder="Frequency" value={frequency ?? ""} onChangeText={setFrequency} />
-      <TextInput placeholder="Next refill date (YYYY-MM-DD)" value={nextRefill ?? ""} onChangeText={setNextRefill} />
-      <TextInput placeholder="Notes" value={notes ?? ""} onChangeText={setNotes} />
-      {err && <Text style={{ color: "red" }}>{err}</Text>}
-      <Button title="Save" onPress={save} />
+    <View style={{ padding: tokens.space(3) }}>
+      <Card style={{ gap: tokens.space(1.5) }}>
+        <Text style={{ fontSize: 18, fontWeight: "600" }}>
+          {initial ? "Edit" : "Add"} prescription
+        </Text>
+        <TextInput placeholder="Name *" value={name} onChangeText={setName} />
+        <TextInput
+          placeholder="Dosage"
+          value={dosage ?? ""}
+          onChangeText={setDosage}
+        />
+        <TextInput
+          placeholder="Frequency"
+          value={frequency ?? ""}
+          onChangeText={setFrequency}
+        />
+        <TextInput
+          placeholder="Next refill date (YYYY-MM-DD)"
+          value={nextRefill ?? ""}
+          onChangeText={setNextRefill}
+        />
+        <TextInput
+          placeholder="Notes"
+          value={notes ?? ""}
+          onChangeText={setNotes}
+        />
+        {err && <Text style={{ color: tokens.color.danger }}>{err}</Text>}
+        <Button title="Save" onPress={save} />
+      </Card>
     </View>
   );
 }

--- a/src/theme/components.tsx
+++ b/src/theme/components.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import {
+  StyleSheet,
+  Text,
+  TextInput as RNTextInput,
+  TextInputProps as RNTextInputProps,
+  TouchableOpacity,
+  TouchableOpacityProps,
+  View,
+  ViewProps,
+} from "react-native";
+import { tokens } from "./tokens";
+
+export function Button({
+  title,
+  style,
+  textStyle,
+  ...props
+}: { title: string; textStyle?: any } & TouchableOpacityProps) {
+  return (
+    <TouchableOpacity style={[styles.button, style]} {...props}>
+      <Text style={[styles.buttonText, textStyle]}>{title}</Text>
+    </TouchableOpacity>
+  );
+}
+
+export function TextInput({ style, ...props }: RNTextInputProps) {
+  return <RNTextInput style={[styles.input, style]} {...props} />;
+}
+
+export function Card({ style, ...props }: ViewProps) {
+  return <View style={[styles.card, style]} {...props} />;
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: tokens.color.primary,
+    paddingVertical: tokens.space(1.5),
+    paddingHorizontal: tokens.space(2),
+    borderRadius: tokens.radius.md,
+    alignItems: "center",
+  },
+  buttonText: {
+    color: tokens.color.surface,
+    fontWeight: "600",
+  },
+  input: {
+    borderColor: tokens.color.text,
+    borderWidth: 1,
+    borderRadius: tokens.radius.sm,
+    padding: tokens.space(1),
+  },
+  card: {
+    backgroundColor: tokens.color.surface,
+    borderColor: tokens.color.surfaceAlt,
+    borderWidth: 1,
+    borderRadius: tokens.radius.md,
+    padding: tokens.space(1.5),
+  },
+});


### PR DESCRIPTION
## Summary
- add shared Button, TextInput, and Card components styled with design tokens
- refactor auth, dashboard, and prescription form screens to use the themed components

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68a3b88c4f7c83268488f152870e7148