### PR TITLE
Validate prescription fields in RxForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "apps/*",
     "packages/*",
     "supabase/*"
-    ]
-  ,
+  ],
   "scripts": {
     "dev": "concurrently -k -n expo,func -c auto,auto \"pnpm --filter app-mobile start:lan\" \"supabase functions serve --env-file ./env/.edge-functions.local\"",
     "typecheck": "tsc -b",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
-    "format": "prettier -w ."
+    "format": "prettier -w .",
+    "test": "node --test src/services/validation.test.js"
   },
   "devDependencies": {
     "concurrently": "^9.2.0",

--- a/src/screens/RxForm.tsx
+++ b/src/screens/RxForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { View, Text } from "react-native";
 import { insertPrescription, updatePrescription, Rx } from "../services/rx";
+import { isNameValid, isDateValid } from "../services/validation";
 import { Button, TextInput, Card } from "../theme/components";
 import { tokens } from "../theme/tokens";
 
@@ -18,7 +19,16 @@ export default function RxForm({
   const [notes, setNotes] = useState(initial?.notes ?? "");
   const [err, setErr] = useState<string | null>(null);
 
+  const [touchedName, setTouchedName] = useState(false);
+  const [touchedDate, setTouchedDate] = useState(false);
+
+  const nameError = isNameValid(name) ? "" : "Name is required";
+  const dateError = isDateValid(nextRefill) ? "" : "Date must be YYYY-MM-DD";
+
   async function save() {
+    setTouchedName(true);
+    setTouchedDate(true);
+    if (nameError || dateError) return;
     try {
       setErr(null);
       const payload = {
@@ -42,29 +52,64 @@ export default function RxForm({
         <Text style={{ fontSize: 18, fontWeight: "600" }}>
           {initial ? "Edit" : "Add"} prescription
         </Text>
-        <TextInput placeholder="Name *" value={name} onChangeText={setName} />
+        <TextInput
+          placeholder="Name *"
+          value={name}
+          onChangeText={setName}
+          onBlur={() => setTouchedName(true)}
+        />
+        <Text
+          style={{
+            color:
+              nameError && touchedName
+                ? tokens.color.danger
+                : tokens.color.text,
+            fontSize: 12,
+          }}
+        >
+          {nameError && touchedName ? nameError : "Required"}
+        </Text>
         <TextInput
           placeholder="Dosage"
           value={dosage ?? ""}
           onChangeText={setDosage}
         />
+        <Text style={{ color: tokens.color.text, fontSize: 12 }}>Optional</Text>
         <TextInput
           placeholder="Frequency"
           value={frequency ?? ""}
           onChangeText={setFrequency}
         />
+        <Text style={{ color: tokens.color.text, fontSize: 12 }}>Optional</Text>
         <TextInput
           placeholder="Next refill date (YYYY-MM-DD)"
           value={nextRefill ?? ""}
           onChangeText={setNextRefill}
+          onBlur={() => setTouchedDate(true)}
         />
+        <Text
+          style={{
+            color:
+              dateError && touchedDate
+                ? tokens.color.danger
+                : tokens.color.text,
+            fontSize: 12,
+          }}
+        >
+          {dateError && touchedDate ? dateError : "YYYY-MM-DD"}
+        </Text>
         <TextInput
           placeholder="Notes"
           value={notes ?? ""}
           onChangeText={setNotes}
         />
+        <Text style={{ color: tokens.color.text, fontSize: 12 }}>Optional</Text>
         {err && <Text style={{ color: tokens.color.danger }}>{err}</Text>}
-        <Button title="Save" onPress={save} />
+        <Button
+          title="Save"
+          onPress={save}
+          disabled={!!(nameError || dateError)}
+        />
       </Card>
     </View>
   );

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -1,0 +1,7 @@
+export function isNameValid(name) {
+  return name.trim().length > 0;
+}
+
+export function isDateValid(date) {
+  return date === "" || /^\d{4}-\d{2}-\d{2}$/.test(date);
+}

--- a/src/services/validation.test.js
+++ b/src/services/validation.test.js
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isNameValid, isDateValid } from "./validation.js";
+
+test("isNameValid", () => {
+  assert.equal(isNameValid(""), false);
+  assert.equal(isNameValid("Metformin"), true);
+  assert.equal(isNameValid("  "), false);
+});
+
+test("isDateValid", () => {
+  assert.equal(isDateValid("2023-12-01"), true);
+  assert.equal(isDateValid("2023/12/01"), false);
+  assert.equal(isDateValid(""), true);
+  assert.equal(isDateValid("2023-2-01"), false);
+});


### PR DESCRIPTION
## Summary
- validate prescription name and refill date before saving
- show helper or error text for each Rx form field and disable saving when invalid
- add unit tests for Rx validation utilities

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68a3ca5f4f888326ac5ca8aa62ea5af6