### PR TITLE
feat: add inventory screen and service

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,11 +3,16 @@ import { supabase } from "./src/lib/supabase";
 import AuthScreen from "./src/screens/Auth";
 import Dashboard from "./src/screens/Dashboard";
 import RxForm from "./src/screens/RxForm";
+import Inventory from "./src/screens/Inventory";
 import { ensureNotificationPermission } from "./src/lib/notify";
 import { Rx } from "./src/services/rx";
 import { View } from "react-native";
 
-type Screen = { name: "auth" } | { name: "home" } | { name: "form"; rx?: Rx };
+type Screen =
+  | { name: "auth" }
+  | { name: "home" }
+  | { name: "form"; rx?: Rx }
+  | { name: "inventory" };
 
 export default function App() {
   const [screen, setScreen] = useState<Screen>({ name: "auth" });
@@ -26,11 +31,16 @@ export default function App() {
     return <RxForm initial={screen.rx} onSaved={() => setScreen({ name: "home" })} />;
   }
 
+  if (screen.name === "inventory") {
+    return <Inventory onBack={() => setScreen({ name: "home" })} />;
+  }
+
   return (
     <View style={{ flex: 1 }}>
       <Dashboard
         onAdd={() => setScreen({ name: "form" })}
         onEdit={(rx) => setScreen({ name: "form", rx })}
+        onInventory={() => setScreen({ name: "inventory" })}
       />
     </View>
   );

--- a/src/screens/Dashboard.tsx
+++ b/src/screens/Dashboard.tsx
@@ -8,9 +8,11 @@ import { scheduleRefillReminder } from "../lib/notify";
 export default function Dashboard({
   onAdd,
   onEdit,
+  onInventory,
 }: {
   onAdd: () => void;
   onEdit: (rx: Rx) => void;
+  onInventory: () => void;
 }) {
   const [items, setItems] = useState<Rx[]>([]);
   const [loading, setLoading] = useState(true);
@@ -48,6 +50,7 @@ export default function Dashboard({
         Your prescriptions
       </Text>
       <Button title="Add prescription" onPress={onAdd} />
+      <Button title="Inventory" onPress={onInventory} />
       {items.length === 0 ? (
         <Text style={{ marginTop: tokens.space(1.5) }}>
           No prescriptions yet.

--- a/src/screens/Inventory.tsx
+++ b/src/screens/Inventory.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, FlatList } from "react-native";
+import { Button, Card } from "../theme/components";
+import { tokens } from "../theme/tokens";
+import { listInventory, InventoryItem } from "../services/inventory";
+import { supabase } from "../lib/supabase";
+
+export default function Inventory({ onBack }: { onBack: () => void }) {
+  const [items, setItems] = useState<InventoryItem[]>([]);
+  const [threshold, setThreshold] = useState<number>(5);
+
+  async function load() {
+    const [invRes, settingsRes] = await Promise.all([
+      listInventory(),
+      supabase
+        .from("user_settings")
+        .select("low_stock_days_threshold")
+        .maybeSingle(),
+    ]);
+    setItems(invRes);
+    if (settingsRes.data?.low_stock_days_threshold)
+      setThreshold(settingsRes.data.low_stock_days_threshold);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  function isLow(item: InventoryItem) {
+    if (!item.expiration_date) return false;
+    const diff =
+      (new Date(item.expiration_date).getTime() - Date.now()) /
+      (1000 * 60 * 60 * 24);
+    return diff <= threshold;
+  }
+
+  return (
+    <View style={{ padding: tokens.space(3), flex: 1 }}>
+      <Text style={{ fontSize: 22, fontWeight: "600" }}>Inventory</Text>
+      <FlatList
+        data={items}
+        keyExtractor={(x) => x.id}
+        renderItem={({ item }) => (
+          <Card
+            style={{
+              marginVertical: tokens.space(0.75),
+              borderColor: isLow(item)
+                ? tokens.color.danger
+                : tokens.color.surfaceAlt,
+            }}
+          >
+            <Text style={{ fontWeight: "600" }}>
+              {item.prescriptions?.name ?? "—"}
+            </Text>
+            <Text>Lot: {item.lot_number ?? "—"}</Text>
+            <Text>Expires: {item.expiration_date ?? "—"}</Text>
+            <Text>Qty: {item.quantity}</Text>
+          </Card>
+        )}
+      />
+      <Button title="Back" onPress={onBack} />
+    </View>
+  );
+}

--- a/src/services/inventory.ts
+++ b/src/services/inventory.ts
@@ -1,0 +1,49 @@
+import { supabase } from "../lib/supabase";
+
+export type InventoryItem = {
+  id: string;
+  user_id: string;
+  prescription_id: string;
+  lot_number?: string | null;
+  expiration_date?: string | null;
+  quantity: number;
+  prescriptions?: { name: string | null } | null;
+};
+
+export async function listInventory(): Promise<InventoryItem[]> {
+  const { data, error } = await supabase
+    .from("inventory")
+    .select("id, user_id, prescription_id, lot_number, expiration_date, quantity, prescriptions(name)")
+    .order("expiration_date", { ascending: true });
+  if (error) throw error;
+  return (data as any) ?? [];
+}
+
+export async function insertInventory(values: Partial<InventoryItem>) {
+  const user = (await supabase.auth.getUser()).data.user;
+  if (!user) throw new Error("Not authed");
+  const payload = { ...values, user_id: user.id };
+  const { data, error } = await supabase
+    .from("inventory")
+    .insert(payload)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return data as InventoryItem;
+}
+
+export async function updateInventory(id: string, values: Partial<InventoryItem>) {
+  const { data, error } = await supabase
+    .from("inventory")
+    .update(values)
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return data as InventoryItem;
+}
+
+export async function deleteInventory(id: string) {
+  const { error } = await supabase.from("inventory").delete().eq("id", id);
+  if (error) throw error;
+}


### PR DESCRIPTION
## Summary
- add inventory CRUD service for Supabase
- create Inventory screen showing remaining quantity and expiration highlighting items nearing threshold
- wire Inventory screen into Dashboard navigation and app router

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `pnpm lint` *(fails: fetch failed for pnpm-9.7.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cc183d248326b284eecdcab6a3ec