### PR TITLE
feat: spike health integrations and reporting exports

### DIFF
--- a/apps/app-mobile/app/emergency.tsx
+++ b/apps/app-mobile/app/emergency.tsx
@@ -1,24 +1,37 @@
 
 import React, { useEffect, useState } from 'react';
-import { View, Text, Image } from 'react-native';
+import { View, Text, Image, TouchableOpacity } from 'react-native';
 import QRCode from 'qrcode';
+import { addToWallet } from '../lib/wallet';
 
 export default function Emergency() {
   const [uri, setUri] = useState<string>('');
+  const payload = JSON.stringify({ a: 'medications', v: 1 });
 
-  useEffect(()=>{
-    (async()=>{
-      const payload = JSON.stringify({ a:'medications', v:1 });
+  useEffect(() => {
+    (async () => {
       const dataUrl = await QRCode.toDataURL(payload);
       setUri(dataUrl);
     })();
-  },[]);
+  }, []);
+
+  const handleWallet = async () => {
+    await addToWallet(payload);
+  };
 
   return (
-    <View style={{ padding: 16, alignItems:'center' }}>
-      <Text style={{ fontSize: 24, fontWeight: '700', marginBottom: 12 }}>Emergency Card</Text>
+    <View style={{ padding: 16, alignItems: 'center', gap: 12 }}>
+      <Text style={{ fontSize: 24, fontWeight: '700' }}>Emergency Card</Text>
       {uri ? <Image source={{ uri }} style={{ width: 200, height: 200 }} /> : null}
-      <Text style={{ marginTop: 12, textAlign:'center' }}>Scan to access your emergency regimen (stored in app).</Text>
+      <Text style={{ textAlign: 'center' }}>
+        Scan to access your emergency regimen (stored in app).
+      </Text>
+      <TouchableOpacity
+        style={{ padding: 12, backgroundColor: '#2563eb', borderRadius: 8 }}
+        onPress={handleWallet}
+      >
+        <Text style={{ color: 'white', fontWeight: '600' }}>Add to Wallet</Text>
+      </TouchableOpacity>
     </View>
   );
 }

--- a/apps/app-mobile/app/index.tsx
+++ b/apps/app-mobile/app/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { Link, useRouter } from 'expo-router';
 import { supabase } from '../lib/supabase';
+import { initHealth, syncCgmData } from '../lib/health';
 
 type Rx = { id: string; name: string; category: string; remaining_quantity: number; frequency: string | null };
 
@@ -13,8 +14,12 @@ export default function Home() {
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => { if (!data.session) router.replace('/auth'); });
+    initHealth().then(() => syncCgmData());
     const load = async () => {
-      const { data, error } = await supabase.from('prescriptions').select('id,name,category,remaining_quantity,frequency').limit(50);
+      const { data, error } = await supabase
+        .from('prescriptions')
+        .select('id,name,category,remaining_quantity,frequency')
+        .limit(50);
       if (!error && data) setItems(data as Rx[]);
       setLoading(false);
     };

--- a/apps/app-mobile/app/reports.tsx
+++ b/apps/app-mobile/app/reports.tsx
@@ -3,25 +3,99 @@ import React from 'react';
 import { View, Text, TouchableOpacity, Alert } from 'react-native';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
+import * as Print from 'expo-print';
 import { supabase } from '../lib/supabase';
 
 export default function Reports() {
-  const exportCsv = async () => {
-    const { data, error } = await supabase.from('prescriptions').select('name,category,remaining_quantity,frequency');
+  const exportPrescriptionsCsv = async () => {
+    const { data, error } = await supabase
+      .from('prescriptions')
+      .select('name,category,remaining_quantity,frequency');
     if (error) return Alert.alert('Error', error.message);
     const header = 'name,category,remaining,frequency\n';
-    const rows = (data||[]).map(d => [d.name, d.category, d.remaining_quantity, d.frequency||''].join(','));
+    const rows = (data || []).map((d) =>
+      [d.name, d.category, d.remaining_quantity, d.frequency || ''].join(',')
+    );
     const csv = header + rows.join('\n');
     const path = FileSystem.cacheDirectory + 'meditrack-prescriptions.csv';
-    await FileSystem.writeAsStringAsync(path, csv, { encoding: FileSystem.EncodingType.UTF8 });
+    await FileSystem.writeAsStringAsync(path, csv, {
+      encoding: FileSystem.EncodingType.UTF8,
+    });
     await Sharing.shareAsync(path, { mimeType: 'text/csv' });
+  };
+
+  const exportGlucoseCsv = async () => {
+    const { data, error } = await supabase
+      .from('blood_glucose_logs')
+      .select('value,recorded_at');
+    if (error) return Alert.alert('Error', error.message);
+    const header = 'value,recorded_at\n';
+    const rows = (data || []).map((d) =>
+      [d.value, d.recorded_at].join(',')
+    );
+    const csv = header + rows.join('\n');
+    const path = FileSystem.cacheDirectory + 'meditrack-glucose.csv';
+    await FileSystem.writeAsStringAsync(path, csv, {
+      encoding: FileSystem.EncodingType.UTF8,
+    });
+    await Sharing.shareAsync(path, { mimeType: 'text/csv' });
+  };
+
+  const exportPdf = async () => {
+    const { data: rx } = await supabase
+      .from('prescriptions')
+      .select('name,category,remaining_quantity,frequency');
+    const { data: logs } = await supabase
+      .from('blood_glucose_logs')
+      .select('value,recorded_at');
+    const rxRows = (rx || [])
+      .map(
+        (r) =>
+          `<tr><td>${r.name}</td><td>${r.category}</td><td>${r.remaining_quantity}</td><td>${
+            r.frequency || ''
+          }</td></tr>`
+      )
+      .join('');
+    const logRows = (logs || [])
+      .map((l) => `<tr><td>${l.value}</td><td>${l.recorded_at}</td></tr>`) // simple
+      .join('');
+    const html = `
+      <h1>MediTrack Report</h1>
+      <h2>Prescriptions</h2>
+      <table border="1" style="border-collapse:collapse"><tr><th>Name</th><th>Category</th><th>Remaining</th><th>Frequency</th></tr>${rxRows}</table>
+      <h2>Blood Glucose Logs</h2>
+      <table border="1" style="border-collapse:collapse"><tr><th>Value</th><th>Recorded At</th></tr>${logRows}</table>
+    `;
+    const file = await Print.printToFileAsync({ html });
+    await Sharing.shareAsync(file.uri, { mimeType: 'application/pdf' });
   };
 
   return (
     <View style={{ padding: 16, gap: 12 }}>
       <Text style={{ fontSize: 24, fontWeight: '600' }}>Reports</Text>
-      <TouchableOpacity style={{ padding: 16, backgroundColor: '#2563eb', borderRadius: 12 }} onPress={exportCsv}>
-        <Text style={{ textAlign: 'center', color: 'white', fontWeight: '600' }}>Export CSV</Text>
+      <TouchableOpacity
+        style={{ padding: 16, backgroundColor: '#2563eb', borderRadius: 12 }}
+        onPress={exportPrescriptionsCsv}
+      >
+        <Text style={{ textAlign: 'center', color: 'white', fontWeight: '600' }}>
+          Export Prescriptions CSV
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={{ padding: 16, backgroundColor: '#0f766e', borderRadius: 12 }}
+        onPress={exportGlucoseCsv}
+      >
+        <Text style={{ textAlign: 'center', color: 'white', fontWeight: '600' }}>
+          Export Glucose CSV
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={{ padding: 16, backgroundColor: '#6b21a8', borderRadius: 12 }}
+        onPress={exportPdf}
+      >
+        <Text style={{ textAlign: 'center', color: 'white', fontWeight: '600' }}>
+          Export PDF
+        </Text>
       </TouchableOpacity>
     </View>
   );

--- a/apps/app-mobile/lib/health.ts
+++ b/apps/app-mobile/lib/health.ts
@@ -1,9 +1,37 @@
 
+import { supabase } from './supabase';
+
+/** Types representing a CGM reading. */
+export interface CgmReading {
+  value: number;
+  timestamp: Date;
+}
+
 /**
  * Health integrations stubs. Implement platform-specific permissions
  * (Apple HealthKit & Google Fit) in native modules or Expo plugins.
  */
 export async function initHealth() {
-  // TODO: request permissions and set up subscriptions.
+  // TODO: request permissions and set up subscriptions with native modules.
   return true;
+}
+
+/** Fetch CGM readings from platform APIs (stub). */
+export async function fetchCgmReadings(): Promise<CgmReading[]> {
+  // TODO: replace with HealthKit/Google Fit queries for glucose samples.
+  return [];
+}
+
+/** Store CGM readings into the `blood_glucose_logs` table. */
+export async function syncCgmData() {
+  const readings = await fetchCgmReadings();
+  if (!readings.length) return;
+
+  await supabase.from('blood_glucose_logs').insert(
+    readings.map((r) => ({
+      value: r.value,
+      recorded_at: r.timestamp.toISOString(),
+      source: 'CGM',
+    }))
+  );
 }

--- a/apps/app-mobile/lib/wallet.ts
+++ b/apps/app-mobile/lib/wallet.ts
@@ -1,0 +1,8 @@
+/**
+ * Stubs for Apple Wallet and Google Wallet pass generation.
+ * Replace these with proper native modules or server-side generation.
+ */
+export async function addToWallet(payload: string) {
+  // TODO: generate and present a wallet pass using the given payload.
+  console.log('Wallet pass not implemented', payload);
+}

--- a/apps/app-mobile/package.json
+++ b/apps/app-mobile/package.json
@@ -14,6 +14,10 @@
     "expo": "^53.0.0",
     "expo-notifications": "~0.28.15",
     "expo-router": "^3.5.0",
+    "expo-file-system": "*",
+    "expo-sharing": "*",
+    "expo-print": "*",
+    "qrcode": "^1.5.3",
     "react": "18.2.0",
     "react-native": "0.76.3"
   },


### PR DESCRIPTION
## Summary
- stub HealthKit/Google Fit sync into `blood_glucose_logs`
- add emergency card wallet entry button and QR code
- support CSV/PDF exports for prescriptions and glucose logs

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*


------
https://chatgpt.com/codex/tasks/task_e_68a3d6d958d083269bd6a90af42bbca7