### PR TITLE
Add age suitability page for App Store review

### DIFF
--- a/docs/appstore-age-suitability.html
+++ b/docs/appstore-age-suitability.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MediTrack Diabetes – Age Suitability</title>
+  <style>
+    body{font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;margin:0;background:#0f172a;color:#e5e7eb}
+    .wrap{max-width:820px;margin:0 auto;padding:28px}
+    h1{font-size:28px;margin:0 0 12px;color:#38bdf8}
+    h2{font-size:20px;margin:24px 0 8px;color:#93c5fd}
+    p,li{color:#e5e7eb}
+    a{color:#93c5fd}
+    .muted{color:#9ca3af}
+    .card{background:#111827;border:1px solid #1f2937;border-radius:14px;padding:18px;margin:12px 0}
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>MediTrack Diabetes – Age Suitability</h1>
+    <p class="muted">Last updated: <span id="d"></span></p>
+
+    <div class="card">
+      <h2>Intended Audience</h2>
+      <p>
+        MediTrack Diabetes is designed for general audiences, including adults and teens with parental guidance.
+        The app helps users track prescriptions, supplies, and medication reminders. It does not contain user-generated
+        public content, gambling, violence, or sexual content.
+      </p>
+    </div>
+
+    <div class="card">
+      <h2>Children & Parental Guidance</h2>
+      <ul>
+        <li>The app is <strong>not intended for children under 13</strong> without parental/guardian supervision.</li>
+        <li>For users under the age of consent in their region, a parent/guardian should manage the account and data.</li>
+        <li>MediTrack Diabetes does not knowingly collect personal information from children under 13.</li>
+      </ul>
+    </div>
+
+    <div class="card">
+      <h2>Content & Features</h2>
+      <ul>
+        <li>No mature themes, shocking content, or simulated gambling.</li>
+        <li>Notifications are limited to medication/supply reminders and low-stock alerts.</li>
+        <li>No public social features or in-app chat/forums.</li>
+      </ul>
+    </div>
+
+    <div class="card">
+      <h2>Data Handling (Summary)</h2>
+      <ul>
+        <li>We collect basic account information and prescription/supply data the user enters to provide core functionality.</li>
+        <li>Data is processed securely and is not shared with third parties for advertising.</li>
+        <li>Parents/guardians may request deletion of a minor’s account data via the contact below.</li>
+      </ul>
+      <p>For full details, see our <a href="./privacy.html">Privacy Policy</a> (coming soon)</p>
+    </div>
+
+    <div class="card">
+      <h2>Contact</h2>
+      <p>
+        Questions about age suitability or child privacy? Contact:
+        <a href="mailto:support@hivoltg.com">support@hivoltg.com</a>
+      </p>
+    </div>
+  </main>
+  <script>document.getElementById('d').textContent=new Date().toLocaleDateString()</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add public age-suitability page for Apple App Store validation

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a426e0f2c48326bb144fb5e711966f