### PR TITLE
Add SMS opt-in consent page

### DIFF
--- a/docs/marketing.html
+++ b/docs/marketing.html
@@ -1,77 +1,154 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>MediTrack Diabetes – App Overview</title>
-  <style>
-    body{font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial;margin:0;background:#f9fafb;color:#111}
-    header{background:#0f172a;color:#fff;padding:40px 20px;text-align:center}
-    header h1{font-size:34px;margin:0}
-    header p{font-size:18px;margin:12px 0 0}
-    main{max-width:900px;margin:0 auto;padding:32px}
-    section{margin-bottom:48px}
-    h2{font-size:24px;margin-bottom:12px;color:#0f172a}
-    p{margin:8px 0}
-    ul{list-style:disc;margin:0 0 0 20px;padding:0}
-    .screenshots{display:flex;flex-wrap:wrap;gap:20px}
-    .screenshots img{max-width:260px;border-radius:12px;border:1px solid #ddd;box-shadow:0 2px 6px rgba(0,0,0,.1)}
-    footer{background:#111827;color:#9ca3af;padding:24px;text-align:center;font-size:14px}
-    a{color:#2563eb}
-  </style>
-</head>
-<body>
-  <header>
-    <h1>MediTrack Diabetes</h1>
-    <p>Stay on top of prescriptions, supplies, and medication reminders – anywhere, anytime.</p>
-  </header>
-  <main>
-    <section>
-      <h2>About the App</h2>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MediTrack Diabetes – App Overview</title>
+    <style>
+      body {
+        font:
+          16px/1.6 system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial;
+        margin: 0;
+        background: #f9fafb;
+        color: #111;
+      }
+      header {
+        background: #0f172a;
+        color: #fff;
+        padding: 40px 20px;
+        text-align: center;
+      }
+      header h1 {
+        font-size: 34px;
+        margin: 0;
+      }
+      header p {
+        font-size: 18px;
+        margin: 12px 0 0;
+      }
+      main {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 32px;
+      }
+      section {
+        margin-bottom: 48px;
+      }
+      h2 {
+        font-size: 24px;
+        margin-bottom: 12px;
+        color: #0f172a;
+      }
+      p {
+        margin: 8px 0;
+      }
+      ul {
+        list-style: disc;
+        margin: 0 0 0 20px;
+        padding: 0;
+      }
+      .screenshots {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 20px;
+      }
+      .screenshots img {
+        max-width: 260px;
+        border-radius: 12px;
+        border: 1px solid #ddd;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+      }
+      footer {
+        background: #111827;
+        color: #9ca3af;
+        padding: 24px;
+        text-align: center;
+        font-size: 14px;
+      }
+      a {
+        color: #2563eb;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>MediTrack Diabetes</h1>
       <p>
-        MediTrack Diabetes is a personal health companion built to help people living with diabetes
-        manage their prescriptions, supplies, and reminders with confidence.
+        Stay on top of prescriptions, supplies, and medication reminders –
+        anywhere, anytime.
       </p>
-    </section>
+    </header>
+    <main>
+      <section>
+        <h2>About the App</h2>
+        <p>
+          MediTrack Diabetes is a personal health companion built to help people
+          living with diabetes manage their prescriptions, supplies, and
+          reminders with confidence.
+        </p>
+      </section>
 
-    <section>
-      <h2>Key Features</h2>
-      <ul>
-        <li><strong>Prescription Tracking</strong> – Add medications or supplies and log frequency & dosage.</li>
-        <li><strong>Inventory Management</strong> – Monitor stock levels, lot numbers, and expiration dates.</li>
-        <li><strong>Reminders</strong> – Get timely push notifications to stay on schedule.</li>
-        <li><strong>Reports</strong> – Generate adherence summaries and export to share with providers.</li>
-        <li><strong>Emergency QR</strong> – Share critical medical details with first responders.</li>
-      </ul>
-    </section>
+      <section>
+        <h2>Key Features</h2>
+        <ul>
+          <li>
+            <strong>Prescription Tracking</strong> – Add medications or supplies
+            and log frequency & dosage.
+          </li>
+          <li>
+            <strong>Inventory Management</strong> – Monitor stock levels, lot
+            numbers, and expiration dates.
+          </li>
+          <li>
+            <strong>Reminders</strong> – Get timely push notifications to stay
+            on schedule.
+          </li>
+          <li>
+            <strong>Reports</strong> – Generate adherence summaries and export
+            to share with providers.
+          </li>
+          <li>
+            <strong>Emergency QR</strong> – Share critical medical details with
+            first responders.
+          </li>
+        </ul>
+      </section>
 
-    <section>
-      <h2>Screenshots (Sample)</h2>
-      <div class="screenshots">
-        <img src="./screenshots/home.svg" alt="Home screen" />
-        <img src="./screenshots/meds.svg" alt="Add prescription" />
-        <img src="./screenshots/list.svg" alt="Medications" />
-        <img src="./screenshots/refill.svg" alt="Reminders screen" />
-        <img src="./screenshots/Emergency.svg" alt="Emergency" />
-        <img src="./screenshots/Post workout.svg" alt="/Post workout" />
-        <img src="./screenshots/graph.svg" alt="graph" />
-        <img src="./screenshots/reminders.svg" alt="reminders" />
+      <section>
+        <h2>Screenshots (Sample)</h2>
+        <div class="screenshots">
+          <img src="./screenshots/home.svg" alt="Home screen" />
+          <img src="./screenshots/meds.svg" alt="Add prescription" />
+          <img src="./screenshots/list.svg" alt="Medications" />
+          <img src="./screenshots/refill.svg" alt="Reminders screen" />
+          <img src="./screenshots/Emergency.svg" alt="Emergency" />
+          <img src="./screenshots/Post workout.svg" alt="/Post workout" />
+          <img src="./screenshots/graph.svg" alt="graph" />
+          <img src="./screenshots/reminders.svg" alt="reminders" />
+        </div>
+        <p>
+          <em>Note: Screenshots are for illustration; actual UI may vary.</em>
+        </p>
+      </section>
 
-      </div>
-      <p><em>Note: Screenshots are for illustration; actual UI may vary.</em></p>
-    </section>
-
-    <section>
-      <h2>Support & Policies</h2>
-      <p>
-        • <a href="./privacy.html">Privacy Policy</a><br>
-        • <a href="./age-suitability.html">Age Suitability</a><br>
-        • Contact: <a href="mailto:support@hivoltgtech.com">support@hivoltg.com</a>
-      </p>
-    </section>
-  </main>
-  <footer>
-    &copy; 2025 HiVoltG Technology Services, LLC. All rights reserved.
-  </footer>
-</body>
+      <section>
+        <h2>Support & Policies</h2>
+        <p>
+          • <a href="./privacy.html">Privacy Policy</a><br />
+          • <a href="./age-suitability.html">Age Suitability</a><br />
+          • <a href="./opt-in.html">SMS Opt-In</a><br />
+          • Contact:
+          <a href="mailto:support@hivoltgtech.com">support@hivoltg.com</a>
+        </p>
+      </section>
+    </main>
+    <footer>
+      &copy; 2025 HiVoltG Technology Services, LLC. All rights reserved.
+    </footer>
+  </body>
 </html>

--- a/docs/opt-in.html
+++ b/docs/opt-in.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MediTrack Diabetes – SMS Opt-In</title>
+    <style>
+      body {
+        font:
+          16px/1.6 system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial;
+        margin: 0;
+        background: #f9fafb;
+        color: #111;
+      }
+      header {
+        background: #0f172a;
+        color: #fff;
+        padding: 40px 20px;
+        text-align: center;
+      }
+      header h1 {
+        font-size: 34px;
+        margin: 0;
+      }
+      header p {
+        font-size: 18px;
+        margin: 12px 0 0;
+      }
+      main {
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 32px;
+      }
+      form {
+        background: #fff;
+        border: 1px solid #d1d5db;
+        padding: 24px;
+        border-radius: 8px;
+      }
+      label {
+        display: block;
+        margin-top: 16px;
+      }
+      input[type="tel"] {
+        width: 100%;
+        padding: 8px;
+        margin-top: 4px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        font-size: 16px;
+      }
+      input[type="checkbox"] {
+        margin-right: 8px;
+      }
+      button {
+        margin-top: 20px;
+        background: #2563eb;
+        color: #fff;
+        border: none;
+        padding: 10px 16px;
+        border-radius: 6px;
+        font-size: 16px;
+        cursor: pointer;
+      }
+      button:hover {
+        background: #1e40af;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>SMS Opt-In</h1>
+      <p>Consent to receive text messages from MediTrack Diabetes</p>
+    </header>
+    <main>
+      <form>
+        <label for="phone">Mobile Number</label>
+        <input id="phone" type="tel" placeholder="555-123-4567" required />
+        <div>
+          <input type="checkbox" id="consent" required />
+          <label for="consent">
+            I agree to receive automated and recurring text messages from
+            MediTrack Diabetes regarding my account and reminders. Message and
+            data rates may apply. Message frequency varies. Reply
+            <strong>STOP</strong> to cancel, <strong>HELP</strong> for help.
+            View our <a href="./privacy.html">Privacy Policy</a>.
+          </label>
+        </div>
+        <button type="submit">Sign Up</button>
+      </form>
+    </main>
+    <footer
+      style="
+        background: #111827;
+        color: #9ca3af;
+        padding: 24px;
+        text-align: center;
+        font-size: 14px;
+      "
+    >
+      &copy; 2025 HiVoltG Technology Services, LLC. All rights reserved.
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add docs/opt-in.html with SMS consent form and opt-out details
- link SMS opt-in page from marketing page

## Testing
- `npx prettier docs/opt-in.html docs/marketing.html -w`
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a429bb7e648326907f30991d0ee358