### PR TITLE
feat: integrate HealthKit and Google Fit for CGM readings

### DIFF
--- a/apps/app-mobile/lib/health.ts
+++ b/apps/app-mobile/lib/health.ts
@@ -1,4 +1,9 @@
 
+import { Platform } from 'react-native';
+import AppleHealthKit, {
+  HealthKitPermissions,
+} from 'react-native-health';
+import GoogleFit, { Scopes } from 'react-native-google-fit';
 import { supabase } from './supabase';
 
 /** Types representing a CGM reading. */
@@ -11,14 +16,88 @@ export interface CgmReading {
  * Health integrations stubs. Implement platform-specific permissions
  * (Apple HealthKit & Google Fit) in native modules or Expo plugins.
  */
+let subscribed = false;
+
 export async function initHealth() {
-  // TODO: request permissions and set up subscriptions with native modules.
-  return true;
+  if (Platform.OS === 'ios') {
+    const permissions: HealthKitPermissions = {
+      permissions: {
+        read: [AppleHealthKit.Constants.Permissions.BloodGlucose],
+      },
+    };
+    const ok = await new Promise<boolean>((resolve) => {
+      AppleHealthKit.initHealthKit(permissions, (error) => {
+        resolve(!error);
+      });
+    });
+    if (!ok) return false;
+    if (!subscribed) {
+      AppleHealthKit.setObserver(
+        { type: AppleHealthKit.Constants.Permissions.BloodGlucose },
+        () => syncCgmData()
+      );
+      subscribed = true;
+    }
+    return true;
+  }
+
+  if (Platform.OS === 'android') {
+    const res = await GoogleFit.authorize({
+      scopes: [Scopes.FITNESS_BLOOD_GLUCOSE_READ],
+    });
+    if (!res.success) return false;
+    if (!subscribed) {
+      GoogleFit.startRecording(() => syncCgmData());
+      subscribed = true;
+    }
+    return true;
+  }
+
+  return false;
 }
 
 /** Fetch CGM readings from platform APIs (stub). */
 export async function fetchCgmReadings(): Promise<CgmReading[]> {
-  // TODO: replace with HealthKit/Google Fit queries for glucose samples.
+  const now = new Date();
+  const startDate = new Date(now.getTime() - 24 * 60 * 60 * 1000); // last 24h
+
+  if (Platform.OS === 'ios') {
+    return new Promise((resolve) => {
+      AppleHealthKit.getBloodGlucoseSamples(
+        {
+          startDate: startDate.toISOString(),
+          endDate: now.toISOString(),
+          unit: 'mg/dL',
+        },
+        (err: any, results: any[]) => {
+          if (err || !results) return resolve([]);
+          resolve(
+            results.map((r) => ({
+              value: r.value,
+              timestamp: new Date(r.startDate),
+            }))
+          );
+        }
+      );
+    });
+  }
+
+  if (Platform.OS === 'android') {
+    try {
+      const samples = await GoogleFit.getSamples({
+        startDate: startDate.toISOString(),
+        endDate: now.toISOString(),
+        dataType: 'com.google.blood_glucose',
+      });
+      return samples.map((s: any) => ({
+        value: s.value,
+        timestamp: new Date(s.startDate),
+      }));
+    } catch (_e) {
+      return [];
+    }
+  }
+
   return [];
 }
 

--- a/apps/app-mobile/package.json
+++ b/apps/app-mobile/package.json
@@ -17,6 +17,8 @@
     "expo-print": "*",
     "expo-router": "^3.5.0",
     "expo-sharing": "*",
+    "react-native-google-fit": "*",
+    "react-native-health": "*",
     "qrcode": "^1.5.3",
     "react": "18.2.0",
     "react-native": "0.76.3"


### PR DESCRIPTION
## Summary
- integrate Apple HealthKit and Google Fit for CGM data
- add subscriptions and runtime permission requests
- add dependencies for native health integrations

## Testing
- `npm test`
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*


------
https://chatgpt.com/codex/tasks/task_e_68a544a335dc8326b439d5e696b6e975