### PR TITLE
feat: register push token

### DIFF
--- a/apps/app-mobile/lib/notifications.ts
+++ b/apps/app-mobile/lib/notifications.ts
@@ -1,3 +1,39 @@
+import { Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import { supabase } from './supabase';
+
+/**
+ * Register the device for push notifications and persist the resulting token
+ * so that we can send targeted notifications to the user later on.
+ */
 export async function registerPushToken(userId: string) {
-  console.log(`Registering push token for ${userId}`);
+  // Ask for the notification permissions first
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+
+  if (finalStatus !== 'granted') return;
+
+  // Retrieve Expo push token. This can later be used to send notifications via Expo
+  const expoPushToken = await Notifications.getExpoPushTokenAsync();
+
+  // FCM/APNS token for direct messaging, if available
+  let deviceToken: string | undefined;
+  if (Platform.OS === 'android') {
+    const { data } = await Notifications.getDevicePushTokenAsync();
+    deviceToken = data;
+  }
+
+  const { error } = await supabase.from('push_tokens').upsert({
+    user_id: userId,
+    expo_token: expoPushToken.data,
+    device_token: deviceToken,
+  });
+
+  if (error) {
+    console.error('Failed to register push token', error);
+  }
 }


### PR DESCRIPTION
## Summary
- obtain Expo/FCM notification token
- store push token in Supabase for targeted notifications
- remove debug logging

## Testing
- `npm test`
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a54b60031c8326804351e7e4504f9c