### PR TITLE
Validate Supabase env vars before client creation

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,14 @@
 
 import { createClient } from "@supabase/supabase-js";
 
-const url = process.env.EXPO_PUBLIC_SUPABASE_URL!;
-const anon = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
+const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const anon = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!url || !anon) {
+  throw new Error(
+    "Missing Supabase configuration: ensure EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY are set."
+  );
+}
 
 export const supabase = createClient(url, anon, {
   auth: { persistSession: true, autoRefreshToken: true },


### PR DESCRIPTION
## Summary
- ensure Supabase client is created only when required env vars are present

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a54d062c408326bf4d50e3ceb4764b