### PR TITLE
Propagate errors from refill request email function

### DIFF
--- a/src/services/refill_requests.ts
+++ b/src/services/refill_requests.ts
@@ -8,7 +8,12 @@ export async function requestRefill(prescription_id: string) {
     .from("refill_requests")
     .insert(payload);
   if (error) throw error;
-  await supabase.functions.invoke("send-refill-email", {
-    body: { prescription_id },
-  });
+  const { data, error: invokeError } = await supabase.functions.invoke(
+    "send-refill-email",
+    {
+      body: { prescription_id },
+    },
+  );
+  if (invokeError) throw invokeError;
+  return data;
 }


### PR DESCRIPTION
## Summary
- check response of `supabase.functions.invoke` when sending refill emails
- surface invoke errors and return function data

## Testing
- `npm test`
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.7.0.tgz; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a55284f9848326890bd7733bc42532