### PR TITLE
refactor: migrate validation service to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc -b",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "format": "prettier -w .",
-    "test": "node --test src/services/validation.test.js"
+    "test": "tsc src/services/validation.test.ts src/services/validation.ts --outDir dist --types node --lib es2020 --esModuleInterop && node --test dist/validation.test.js"
   },
   "devDependencies": {
     "concurrently": "^9.2.0",

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -1,7 +1,0 @@
-export function isNameValid(name) {
-  return name.trim().length > 0;
-}
-
-export function isDateValid(date) {
-  return date === "" || /^\d{4}-\d{2}-\d{2}$/.test(date);
-}

--- a/src/services/validation.test.ts
+++ b/src/services/validation.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { isNameValid, isDateValid } from "./validation.js";
+import { isNameValid, isDateValid } from "./validation";
 
 test("isNameValid", () => {
   assert.equal(isNameValid(""), false);

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -1,0 +1,7 @@
+export function isNameValid(name: string): boolean {
+  return name.trim().length > 0;
+}
+
+export function isDateValid(date: string): boolean {
+  return date === "" || /^\d{4}-\d{2}-\d{2}$/.test(date);
+}


### PR DESCRIPTION
## Summary
- migrate validation service and its tests to TypeScript
- compile TypeScript before running tests

## Testing
- `npm test`
- `npm run typecheck` *(pass)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a553c706b88326917ec811dacb874f