### PR TITLE
chore: add prettier ignore patterns

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+docs/**
+*.png
+*.jpg
+*.jpeg
+*.webp
+*.svg


### PR DESCRIPTION
## Summary
- avoid formatting docs and images via Prettier ignore patterns

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57792cf0483268e21c8bc361c1c4b