### PR TITLE
chore(tooling): ESLint v9 flat config + npm registry pin (docs-safe)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
   "devDependencies": {
     "concurrently": "^9.2.0",
     "eslint": "^9.9.0",
-    "typescript-eslint": "^7.18.0",
-    "prettier": "^3.3.3",
-    "typescript": "^5.5.4",
     "@eslint/js": "^9.9.0",
     "typescript-eslint": "^8.4.0",
-    "globals": "^15.8.0"
+    "globals": "^15.8.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- ensure ESLint v9 flat config ignores docs/ and .github/
- pin npm registry
- pin devDependencies for ESLint tooling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a5710fa2048326ae4a0c09e5fc6c4c