### PR TITLE
ci: pass validated tag to script

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -57,8 +57,9 @@ jobs:
       - name: Create or update tag
         uses: actions/github-script@v7
         with:
+          tag: ${{ steps.validate.outputs.tag }}
           script: |
-            const tag = "${{ steps.validate.outputs.tag }}";
+            const tag = core.getInput('tag');
             const sha = "${{ steps.sha.outputs.sha }}";
             let exists = true;
             try {


### PR DESCRIPTION
## Summary
- pass validated tag as input to GitHub Script step in rc-release workflow

## Testing
- `npm test`
- `gh workflow run rc-release.yml -f tag=rc-0.1.1` *(fails: command not found: gh)*
- `apt-get update` *(fails: The repository ... InRelease is not signed)*
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c9ea743c83269b0fe78ccb8afec5